### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "re:watch": "bsb -make-world -w"
   },
   "keywords": [
-    "BuckleScript",
-    "Rescript",
+    "rescript",
     "TailwindCSS",
     "Headless UI",
     "Tailwind"


### PR DESCRIPTION
We will be detecting all npm packages that are tagged with the `rescript` keyword (case sensitive!) and will list them in our docs website similarly like this:

![image](https://user-images.githubusercontent.com/1121889/98806264-32344200-2419-11eb-9147-52703fa7b6bd.png)

This commit also removes the `BuckleScript` keyword, because we should really stop promoting the old name with new ReScript packages.
