### PR TITLE
correct Button -> Option for RadioGroup.Option module

### DIFF
--- a/src/RadioGroup.res
+++ b/src/RadioGroup.res
@@ -17,7 +17,7 @@
       ~disabled: bool=?,
       ~className: string=?,
       ~children: renderProps => React.element,
-    ) => React.element = "Button"
+    ) => React.element = "Option"
   }
 
   module Label = {


### PR DESCRIPTION
This PR includes a small error fix for the `RadioGroup.Option` module.


<img width="556" alt="Screenshot 2022-01-22 at 22 59 19" src="https://user-images.githubusercontent.com/11720377/150656819-abf661f8-f430-4d8c-ac9c-903d15c4ba56.png">