### PR TITLE
Fix open prop on Dialog

### DIFF
--- a/src/Dialog.res
+++ b/src/Dialog.res
@@ -1,7 +1,7 @@
 type renderProps = {@as("open") _open: bool}
 @module("@headlessui/react") @react.component
 external make: (
-  ~open_: bool=?,
+  @as("open") ~_open: bool=?,
   ~onClose: unit => unit=?,
   ~initialFocus: React.ref<React.element>=?,
   ~_as: 'asType=?,


### PR DESCRIPTION
The `open` prop was not binding to the correct name. 